### PR TITLE
Handle missing envs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ SUPABASE_URL=your_supabase_url
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 SUPABASE_BUCKET_NAME=your_supabase_bucket_name
 LANGUAGES=rust,python,typescript
+CUSTOM_SITE_URL=https://example.com

--- a/README.md
+++ b/README.md
@@ -24,11 +24,18 @@ Trust Vibe.
    - `GEMINI_API_KEY`: Google Gemini API Key
    - `LANGUAGES`: Comma-separated list of languages for GitHub Trending (e.g., `rust,python,typescript`)
 
-2. Build and run
-   ```
-   cargo run -p orchestrator --release
+2. (Optional) set additional environment variables
    - `CUSTOM_SITE_URL`: URL of the website you want to fetch
    - `XAI_API_KEY`: xAI API Key used for live search
+
+3. Build
+   ```bash
+   cargo build --release
+   ```
+
+4. Run
+   ```bash
+   ./target/release/orchestrator
    ```
 
 ## Deploy to Render


### PR DESCRIPTION
## Summary
- check `XAI_API_KEY` and `CUSTOM_SITE_URL` before spawning optional crawlers
- document optional variables in README
- add `CUSTOM_SITE_URL` to `.env.example`
- document building with `cargo build --release` and running `./target/release/orchestrator`

## Testing
- `cargo check -p orchestrator` *(fails: could not download crates)*
- `rustup component add rustfmt` *(fails: could not download file)*