### PR TITLE
Fix missing warn macro import

### DIFF
--- a/crates/custom_site/src/lib.rs
+++ b/crates/custom_site/src/lib.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 use scraper::Html;
 use std::env;
 use time::OffsetDateTime;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Clone)]
 struct SiteFetcher {


### PR DESCRIPTION
## Summary
- fix `custom_site` compile error by importing `warn` from `tracing`

## Testing
- `cargo build --release` *(fails: failed to download crates)*