### PR TITLE
Fix warn macro import in custom crawler

### DIFF
--- a/crates/custom_site/src/lib.rs
+++ b/crates/custom_site/src/lib.rs
@@ -3,7 +3,7 @@ use reqwest::Client;
 use scraper::Html;
 use std::env;
 use time::OffsetDateTime;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Clone)]
 struct SiteFetcher {


### PR DESCRIPTION
## Summary
- import `warn` macro in custom_site

## Testing
- `cargo test --workspace --quiet` *(fails: Could not connect to server)*